### PR TITLE
Add Ruby build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: build
+
+on: [pull_request, push]
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - head
+          - '3.3'
+          - '3.2'
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,4 +45,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   1.17.3
+   2.4.19

--- a/Rakefile
+++ b/Rakefile
@@ -7,12 +7,12 @@ task :default => :spec
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new do |t|
   t.verbose    = false
-  t.rspec_opts = %w(-w -rspec_helper)
+  t.rspec_opts = "-w -rspec_helper"
 
   if ENV.include?("CI") or ENV.include?("TRAVIS")
-    t.rspec_opts += %w(--format progress)
+    t.rspec_opts += " --format progress"
   else
-    t.rspec_opts += %w(--format documentation)
+    t.rspec_opts += " --format documentation"
   end
 end
 

--- a/lib/stupidedi/versions/common/element_types/r.rb
+++ b/lib/stupidedi/versions/common/element_types/r.rb
@@ -284,7 +284,9 @@ module Stupidedi
               if rounded.zero?
                 "0" * definition.min_length
               else
-                sign + rounded.abs.to_s("F").
+                base = rounded.abs
+                base = base.is_a?(BigDecimal) ? base : BigDecimal(base)
+                sign + base.to_s("F").
                   gsub(/^0+/, ""). # leading zeros
                   gsub(/0+$/, ""). # trailing zeros
                   gsub(/\.$/, ""). # trailing decimal point

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ rescue LoadError
 end
 
 require File.expand_path("../../lib/stupidedi", __FILE__)
+require "ruby/blank"
 require "pp"
 require "ostruct"
 


### PR DESCRIPTION
Test across multiple Ruby versions, including future versions. This way we have an easier time updating onelife to newer Ruby versions.

I've copied updates necessary from upstream, and added a couple later Ruby versions:

- https://github.com/kputnam/stupidedi/pull/245
- https://github.com/kputnam/stupidedi/commit/c3f40086cfc1663c3fe1126a003ebcd79f57f79b